### PR TITLE
Fix textarea default test typo

### DIFF
--- a/Firmware/Radiation_Detector/lib/lvgl/tests/src/test_cases/test_textarea.c
+++ b/Firmware/Radiation_Detector/lib/lvgl/tests/src/test_cases/test_textarea.c
@@ -19,7 +19,7 @@ void tearDown(void)
     /* Function run after every test */
 }
 
-void test_textarea_should_have_valid_documented_defualt_values(void)
+void test_textarea_should_have_valid_documented_default_values(void)
 {
     TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
     TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));

--- a/Libraries/lvgl/tests/src/test_cases/test_textarea.c
+++ b/Libraries/lvgl/tests/src/test_cases/test_textarea.c
@@ -19,7 +19,7 @@ void tearDown(void)
     /* Function run after every test */
 }
 
-void test_textarea_should_have_valid_documented_defualt_values(void)
+void test_textarea_should_have_valid_documented_default_values(void)
 {
     TEST_ASSERT(lv_textarea_get_cursor_click_pos(textarea));
     TEST_ASSERT_EQUAL(0U, lv_textarea_get_one_line(textarea));


### PR DESCRIPTION
## Summary
- fix typo in `test_textarea_should_have_valid_documented_default_values`
- adjust duplicate test file in firmware copy

## Testing
- `python3 Libraries/lvgl/tests/main.py test`
- `python3 Firmware/Radiation_Detector/lib/lvgl/tests/main.py test`


------
https://chatgpt.com/codex/tasks/task_e_683f68ce472483208530cb16d5017a70